### PR TITLE
fix?:  alloc error

### DIFF
--- a/nimPNG/nimz.nim
+++ b/nimPNG/nimz.nim
@@ -233,8 +233,7 @@ proc HuffmanTree_makeFromLengths(tree: var HuffmanTree, bitlen: openarray[int], 
   HuffmanTree_make2DTree(tree)
 
 proc make_coin(): Coin =
-  new(result)
-  result.symbols = @[]
+  result = Coin(weight: 0, symbols: @[])
 
 proc coin_copy(c1, c2: Coin) =
   c1.weight = c2.weight


### PR DESCRIPTION
Trying to fix this random error that happens in nim-status-client when calling generateIdenticon after receiving a group status message:

```
/home/richard/status/nim-status-client/src/nim_status_client.nim(167) nim_status_client
/home/richard/status/nim-status-client/src/nim_status_client.nim(164) mainProc
/home/richard/status/nim-status-client/vendor/nimqml/src/nimqml/private/qapplication.nim(8) exec
/home/richard/status/nim-status-client/vendor/nimqml/src/nimqml/private/qobject.nim(49) qobjectCallback
/home/richard/status/nim-status-client/vendor/nimqml/src/nimqml/private/qobject.nim(34) onSlotCalled
/home/richard/status/nim-status-client/vendor/nimbus-build-system/vendor/Nim/lib/core/macros.nim(566) onSlotCalled
/home/richard/status/nim-status-client/src/status/signals/core.nim(72) receiveSignal
/home/richard/status/nim-status-client/src/status/signals/core.nim(51) processSignal
/home/richard/status/nim-status-client/src/status/signals/messages.nim(39) fromEvent
/home/richard/status/nim-status-client/src/status/signals/messages.nim(139) toChat
/home/richard/status/nim-status-client/src/status/signals/messages.nim(61) toChatMember
/home/richard/status/nim-status-client/src/status/libstatus/accounts.nim(49) generateIdenticon
/home/richard/status/nim-status-client/vendor/nim-status/src/nim_status/lib.nim(45) identicon
/home/richard/status/nim-status-client/vendor/nim-status/src/nim_status/lib/identicon.nim(101) generateBase64
/home/richard/status/nim-status-client/vendor/nim-status/src/nim_status/lib/identicon.nim(90) renderBase64
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG.nim(2963) encodePNG
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG.nim(2950) encodePNG
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG.nim(2869) encoderCore
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG.nim(2831) frameConvert
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG.nim(2643) preProcessScanLines
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG.nim(2618) filter
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG/filters.nim(289) filterBruteForce
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG/nimz.nim(1296) zlib_compress
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG/nimz.nim(1199) nzDeflate
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG/nimz.nim(1053) deflateDynamic
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG/nimz.nim(384) HuffmanTree_makeFromFrequencies
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG/nimz.nim(347) huffman_code_lengths
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG/nimz.nim(248) init_coins
/home/richard/status/nim-status-client/vendor/nimPNG/nimPNG/nimz.nim(236) make_coin
/home/richard/status/nim-status-client/vendor/nimbus-build-system/vendor/Nim/lib/system/gc.nim(440) newObj
/home/richard/status/nim-status-client/vendor/nimbus-build-system/vendor/Nim/lib/system/alloc.nim(783) rawAlloc
```

I don't know if this code fixes it, but I havent been able to reproduce the issue anymore.

Checking the C code I don't see many differences between the C code generated by the current code and proposed change:



Current Code:
```c
N_LIB_PRIVATE N_NIMCALL(tyObject_CoincolonObjectType___40T2Oa6M44N8jELpuJBAPw*, make_coin__RTAjtHNuWJS0sqsbiVPxlw)(void) {
	tyObject_CoincolonObjectType___40T2Oa6M44N8jELpuJBAPw* result;
	nimfr_("make_coin", "/home/richard/Desktop/aaa.nim");
	result = (tyObject_CoincolonObjectType___40T2Oa6M44N8jELpuJBAPw*)0;
	nimln_(6, "/home/richard/Desktop/aaa.nim");
	result = (tyObject_CoincolonObjectType___40T2Oa6M44N8jELpuJBAPw*) newObj((&NTI__hx0qdgLnz9ciHaJ2n9a3mMcg_), sizeof(tyObject_CoincolonObjectType___40T2Oa6M44N8jELpuJBAPw));
	nimln_(7, "/home/richard/Desktop/aaa.nim");
	if ((*result).symbols) { nimGCunrefNoCycle((*result).symbols); (*result).symbols = NIM_NIL; }
	popFrame();
	return result;
}
```

Proposed:
```c
N_LIB_PRIVATE N_NIMCALL(tyObject_CoincolonObjectType___40T2Oa6M44N8jELpuJBAPw*, make_coin__RTAjtHNuWJS0sqsbiVPxlw)(void) {
	tyObject_CoincolonObjectType___40T2Oa6M44N8jELpuJBAPw* result;
	tyObject_CoincolonObjectType___40T2Oa6M44N8jELpuJBAPw* T1_;
	nimfr_("make_coin", "/home/richard/Desktop/aaa.nim");
	result = (tyObject_CoincolonObjectType___40T2Oa6M44N8jELpuJBAPw*)0;
	nimln_(11, "/home/richard/Desktop/aaa.nim");
	T1_ = (tyObject_CoincolonObjectType___40T2Oa6M44N8jELpuJBAPw*)0;
	T1_ = (tyObject_CoincolonObjectType___40T2Oa6M44N8jELpuJBAPw*) newObj((&NTI__hx0qdgLnz9ciHaJ2n9a3mMcg_), sizeof(tyObject_CoincolonObjectType___40T2Oa6M44N8jELpuJBAPw));
	(*T1_).weight = 0.0;
	if ((*T1_).symbols) { nimGCunrefNoCycle((*T1_).symbols); (*T1_).symbols = NIM_NIL; }
	result = T1_;
	popFrame();
	return result;
}
```